### PR TITLE
Use controller to compute health potion cost

### DIFF
--- a/fabula_charsheet/data/models/state.py
+++ b/fabula_charsheet/data/models/state.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 from pydantic import BaseModel
 
 from .status import Status
-from pages.controller import CharacterController
-from data.models.character import Character
-
 
 
 class CharState(BaseModel):
@@ -13,6 +10,10 @@ class CharState(BaseModel):
     minus_ip: int = 0
     statuses: list[Status] = list()
 
-    def use_health_potion(self):
+    def use_health_potion(self, controller):
         self.minus_hp = max(0, self.minus_hp - 50)
-        self.minus_ip = min(CharacterController.max_ip(), self.minus_ip + (2 if "deep_pockets" in Character.heroic_skills else 3) )
+        has_deep_pockets = any(
+            skill.name == "deep_pockets" for skill in controller.character.heroic_skills
+        )
+        ip_cost = 2 if has_deep_pockets else 3
+        self.minus_ip = min(controller.max_ip(), self.minus_ip + ip_cost)

--- a/fabula_charsheet/pages/character_view/view.py
+++ b/fabula_charsheet/pages/character_view/view.py
@@ -2,7 +2,7 @@ import streamlit as st
 
 import config
 from data.models import Status, AttributeName, Weapon, GripType, WeaponCategory, \
-    WeaponRange, ClassName, LocNamespace, Character
+    WeaponRange, ClassName, LocNamespace
 from pages.controller import CharacterController
 from pages.utils import WeaponTableWriter, ArmorTableWriter, SkillTableWriter, SpellTableWriter, DanceTableWriter, \
     AccessoryTableWriter, ItemTableWriter, TherioformTableWriter, ShieldTableWriter, BondTableWriter, \
@@ -223,8 +223,15 @@ def build(controller: CharacterController):
 
             col1, col2, col3 = st.columns(3)
             with col1:
-                if st.button(loc.page_view_health_potion, disabled=(current_ip < 2 if "deep_pockets" in Character.heroic_skills else current_ip < 3), use_container_width=True):
-                    st.session_state.state_controller.state.use_health_potion()
+                has_deep_pockets = any(
+                    skill.name == "deep_pockets" for skill in controller.character.heroic_skills
+                )
+                if st.button(
+                    loc.page_view_health_potion,
+                    disabled=(current_ip < 2 if has_deep_pockets else current_ip < 3),
+                    use_container_width=True,
+                ):
+                    st.session_state.state_controller.state.use_health_potion(controller)
                     st.rerun()
             with col2:
                 if st.button(loc.page_view_mana_potion, disabled=(current_ip < 3), use_container_width=True):


### PR DESCRIPTION
## Summary
- pass controller to `CharState.use_health_potion` and compute IP cost via heroic skills
- update character view to use controller when consuming health potion

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a19986506c83329e82f099cbcbd92e