### PR TITLE
Add comprehensive unit tests for core mechanisms

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,145 @@
+import sys
+import types
+import json
+from pathlib import Path
+import pytest
+
+# Ensure package root in path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+PKG = ROOT / 'fabula_charsheet'
+if str(PKG) not in sys.path:
+    sys.path.insert(0, str(PKG))
+
+# Stub streamlit module
+class SessionState(dict):
+    __getattr__ = dict.get
+    __setattr__ = dict.__setitem__
+
+st_stub = types.SimpleNamespace(session_state=SessionState())
+sys.modules.setdefault('streamlit', st_stub)
+
+# Stub yaml module using json
+yaml_stub = types.SimpleNamespace()
+
+def _yaml_load(stream, Loader=None):
+    return json.load(stream)
+
+yaml_stub.load = _yaml_load
+yaml_stub.SafeLoader = yaml_stub.UnsafeLoader = yaml_stub.Loader = object
+sys.modules.setdefault('yaml', yaml_stub)
+
+# Stub pydantic module
+pydantic_stub = types.SimpleNamespace()
+
+class BaseModel:
+    def __init__(self, **data):
+        for k, v in data.items():
+            setattr(self, k, v)
+
+def Field(*, default=None, default_factory=None):
+    if default_factory is not None:
+        return default_factory()
+    return default
+
+class RootModel(BaseModel):
+    def __init__(self, root=None):
+        super().__init__()
+        self.root = root
+
+    def __class_getitem__(cls, item):
+        return cls
+
+class ConfigDict(dict):
+    pass
+
+def conint(**kwargs):
+    return int
+
+pydantic_stub.BaseModel = BaseModel
+pydantic_stub.Field = Field
+pydantic_stub.RootModel = RootModel
+pydantic_stub.ConfigDict = ConfigDict
+pydantic_stub.conint = conint
+sys.modules.setdefault('pydantic', pydantic_stub)
+
+# Stub annotated_types
+annotated_stub = types.SimpleNamespace(Len=lambda *args, **kwargs: None)
+sys.modules.setdefault('annotated_types', annotated_stub)
+
+@pytest.fixture(scope='session')
+def streamlit_stub():
+    return st_stub
+
+@pytest.fixture(autouse=True)
+def clear_session_state(streamlit_stub):
+    streamlit_stub.session_state.clear()
+    yield
+    streamlit_stub.session_state.clear()
+
+@pytest.fixture
+def assets_dir(tmp_path: Path) -> Path:
+    # Build minimal assets structure as JSON
+    equipment = tmp_path / 'equipment'
+    equipment.mkdir()
+    weapons = [
+        {
+            "name": "staff",
+            "weapon_category": "arcane",
+            "range": "melee",
+            "accuracy": ["dexterity", "might"],
+            "bonus_damage": 6,
+        }
+    ]
+    (equipment / 'weapons.yaml').write_text(json.dumps(weapons))
+    (equipment / 'armors.yaml').write_text('[]')
+    (equipment / 'shields.yaml').write_text('[]')
+
+    classes = tmp_path / 'classes'
+    classes.mkdir()
+    elementalist = {
+        "name": "elementalist",
+        "skills": [
+            {"name": "cataclysm", "current_level": 0, "max_level": 3},
+            {"name": "elemental_magic", "current_level": 0, "max_level": 10, "can_add_spell": True},
+        ]
+    }
+    sharpshooter = {
+        "name": "sharpshooter",
+        "martial_ranged": True,
+        "martial_shields": True,
+        "skills": []
+    }
+    arcanist = {
+        "name": "arcanist",
+        "skills": [
+            {"name": "arcane_circle", "current_level": 0, "max_level": 4},
+            {"name": "arcane_regeneration", "current_level": 0, "max_level": 2}
+        ]
+    }
+    (classes / 'elementalist.yaml').write_text(json.dumps(elementalist))
+    (classes / 'sharpshooter.yaml').write_text(json.dumps(sharpshooter))
+    (classes / 'arcanist.yaml').write_text(json.dumps(arcanist))
+
+    spells = tmp_path / 'spells'
+    spells.mkdir()
+    (spells / 'elementalist.yaml').write_text(json.dumps([
+        {"name": "aura", "is_offensive": False, "mp_cost": 5, "target": "one_creature", "duration": "scene"}
+    ]))
+    (spells / 'spiritist.yaml').write_text(json.dumps([
+        {"name": "heal", "is_offensive": False, "mp_cost": 5, "target": "one_creature", "duration": "scene"}
+    ]))
+
+    skills_dir = tmp_path / 'skills'
+    skills_dir.mkdir()
+    (skills_dir / 'heroic_skills.yaml').write_text(json.dumps([
+        {"name": "ambidextrous"}
+    ]))
+
+    special = tmp_path / 'special'
+    special.mkdir()
+    (special / 'dances.yaml').write_text('[]')
+    (special / 'therioforms.yaml').write_text('[]')
+
+    return tmp_path

--- a/tests/test_char_class.py
+++ b/tests/test_char_class.py
@@ -1,0 +1,35 @@
+from fabula_charsheet.data import compendium
+from fabula_charsheet.data.models.skill import Skill
+
+
+def _get_class(name, assets_dir):
+    compendium.COMPENDIUM = None
+    compendium.init(assets_dir)
+    cls = compendium.COMPENDIUM.classes.get_class(name)
+    cls.skills = [Skill(**s) if isinstance(s, dict) else s for s in cls.skills]
+    return cls
+
+
+def test_char_class_methods(assets_dir):
+    elementalist = _get_class('elementalist', assets_dir)
+    # class_level
+    elementalist.skills[0].current_level = 2
+    elementalist.skills[1].current_level = 1
+    assert elementalist.class_level() == 3
+    # get_skill and get_skill_level
+    skill = elementalist.get_skill('cataclysm')
+    assert skill is not None
+    assert elementalist.get_skill('unknown') is None
+    elementalist.levelup_skill('cataclysm')
+    assert elementalist.get_skill_level('cataclysm') == skill.current_level
+    # get_spell_skill
+    spell_skill = elementalist.get_spell_skill()
+    assert spell_skill is not None and spell_skill.can_add_spell
+    # can_equip_list and can_equip_weapon for sharpshooter
+    sharpshooter = _get_class('sharpshooter', assets_dir)
+    assert set(sharpshooter.can_equip_list()) == {'martial_ranged', 'martial_shields'}
+    assert sharpshooter.can_equip_weapon('ranged')
+    assert not sharpshooter.can_equip_weapon('melee')
+    # clear_skills
+    elementalist.clear_skills()
+    assert elementalist.skills == []

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -1,0 +1,77 @@
+import pytest
+import json
+
+from fabula_charsheet.data.models import Character, HeroicSkill, HeroicSkillName
+from fabula_charsheet.data.models.character import InvalidCharacterField
+from fabula_charsheet.data import compendium
+from fabula_charsheet.data.localizator import init_localizator
+from fabula_charsheet.data.models import LangEnum
+
+
+def _setup_loc(streamlit_stub, tmp_path):
+    en_dir = tmp_path / 'en'
+    en_dir.mkdir()
+    content = {
+        "error_name_empty": "Name should not be empty.",
+        "error_invalid_level": "Level {level} should be between 1 and 60.",
+        "error_identity_empty": "Identity should not be empty.",
+        "error_theme_empty": "Theme should not be empty.",
+        "error_origin_empty": "Origin should not be empty."
+    }
+    (en_dir / 'base.yaml').write_text(json.dumps(content))
+    ru_dir = tmp_path / 'ru'
+    ru_dir.mkdir()
+    (ru_dir / 'base.yaml').write_text('{}')
+    init_localizator(tmp_path)
+    return streamlit_stub.session_state['localizator'].get(LangEnum.en)
+
+
+def test_character_field_validations(streamlit_stub, tmp_path):
+    loc = _setup_loc(streamlit_stub, tmp_path)
+    char = Character()
+    char.set_level(10, loc)
+    assert char.level == 10
+    with pytest.raises(InvalidCharacterField):
+        char.set_level(0, loc)
+    with pytest.raises(InvalidCharacterField):
+        char.set_identity('', loc)
+    char.set_identity('Hero', loc)
+    with pytest.raises(InvalidCharacterField):
+        char.set_name('', loc)
+    char.set_name('Alice', loc)
+    with pytest.raises(InvalidCharacterField):
+        char.set_theme('', loc)
+    char.set_theme('Hope', loc)
+    with pytest.raises(InvalidCharacterField):
+        char.set_origin('', loc)
+    char.set_origin('Village', loc)
+
+
+def test_character_utility_methods(assets_dir, streamlit_stub, tmp_path):
+    loc = _setup_loc(streamlit_stub, tmp_path)
+    compendium.COMPENDIUM = None
+    compendium.init(assets_dir)
+    c = compendium.COMPENDIUM
+    from fabula_charsheet.data.models.skill import Skill
+    for cls in c.classes.classes:
+        cls.skills = [Skill(**s) if isinstance(s, dict) else s for s in cls.skills]
+    char = Character()
+    arcanist = c.classes.get_class('arcanist')
+    arcanist.skills[0].current_level = 1
+    arcanist.skills[1].current_level = 2
+    char.classes = [arcanist]
+    assert char.get_n_skill() == 3
+    assert char.get_class('arcanist') is arcanist
+    assert char.get_class(None) is None
+    spells = c.spells.get_spells('elementalist')
+    char.spells = {'elementalist': spells}
+    assert char.get_spells_by_class('elementalist') == spells
+    assert char.get_spells_by_class(None) == []
+    spiritist_spells = c.spells.get_spells('spiritist')
+    char.spells['spiritist'] = spiritist_spells
+    assert len(char.get_all_spells()) == len(spells) + len(spiritist_spells)
+    hs = HeroicSkill(name='deep_pockets')
+    char.heroic_skills = [hs]
+    assert char.has_heroic_skill(HeroicSkillName.deep_pockets)
+    char.heroic_skills = []
+    assert not char.has_heroic_skill(HeroicSkillName.deep_pockets)

--- a/tests/test_compendium.py
+++ b/tests/test_compendium.py
@@ -1,0 +1,31 @@
+from fabula_charsheet.data import compendium
+
+
+def test_compendium_initialization(assets_dir):
+    compendium.COMPENDIUM = None
+    compendium.init(assets_dir)
+    assert compendium.COMPENDIUM is not None
+    equipment = compendium.COMPENDIUM.equipment
+    categories = equipment.weapons_by_categories()
+    assert 'arcane' in categories
+    assert all(w.weapon_category == 'arcane' for w in categories['arcane'])
+
+
+def test_compendium_retrieval_methods(assets_dir):
+    compendium.COMPENDIUM = None
+    compendium.init(assets_dir)
+    c = compendium.COMPENDIUM
+    from fabula_charsheet.data.models.skill import Skill
+    for cls in c.classes.classes:
+        cls.skills = [Skill(**s) if isinstance(s, dict) else s for s in cls.skills]
+    arcanist = c.classes.get_class('arcanist')
+    assert arcanist is not None and arcanist.name == 'arcanist'
+    assert c.classes.get_class('unknown') is None
+    spells = c.spells.get_spells('elementalist')
+    assert isinstance(spells, list) and spells
+    assert c.spells.get_spells('unknown') == []
+    heroic = c.heroic_skills.get_skill('ambidextrous')
+    assert heroic is not None and heroic.name == 'ambidextrous'
+    assert c.heroic_skills.get_skill('unknown') is None
+    skill = arcanist.skills[0]
+    assert c.get_class_name_from_skill(skill) == 'arcanist'

--- a/tests/test_localizator.py
+++ b/tests/test_localizator.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import pytest
+
+from fabula_charsheet.data.localizator import init_localizator
+from fabula_charsheet.data.models import LangEnum
+
+
+def test_init_localizator_loads_translations(streamlit_stub, tmp_path):
+    en_dir = tmp_path / 'en'
+    ru_dir = tmp_path / 'ru'
+    en_dir.mkdir()
+    ru_dir.mkdir()
+    (en_dir / 'base.yaml').write_text('{"error_name_empty": "Name should not be empty.", "bond_explanation": "About Bonds"}')
+    (ru_dir / 'base.yaml').write_text('{"error_name_empty": "Имя не должно быть пустым."}')
+    init_localizator(tmp_path)
+    localizator = streamlit_stub.session_state['localizator']
+    en = localizator.get(LangEnum.en)
+    ru = localizator.get(LangEnum.ru)
+    assert en.error_name_empty == "Name should not be empty."
+    assert ru.error_name_empty == "Имя не должно быть пустым."
+    assert ru.bond_explanation == en.bond_explanation
+
+
+def test_init_localizator_duplicate_keys(tmp_path, streamlit_stub):
+    en_dir = tmp_path / 'en'
+    ru_dir = tmp_path / 'ru'
+    en_dir.mkdir()
+    ru_dir.mkdir()
+    (en_dir / 'a.yaml').write_text('{"key1": "value1"}')
+    (en_dir / 'b.yaml').write_text('{"key1": "value2"}')
+    (ru_dir / 'a.yaml').write_text('{"key1": "value1"}')
+    with pytest.raises(ValueError):
+        init_localizator(tmp_path)

--- a/tests/test_saved_characters.py
+++ b/tests/test_saved_characters.py
@@ -1,0 +1,9 @@
+from fabula_charsheet.data import saved_characters
+
+
+def test_saved_characters_init(tmp_path):
+    saved_characters.SAVED_CHARS = None
+    (tmp_path / 'char.yaml').write_text('{"name": "Test"}')
+    saved_characters.init(tmp_path)
+    assert saved_characters.SAVED_CHARS is not None
+    assert saved_characters.SAVED_CHARS.char_list


### PR DESCRIPTION
## Summary
- Add unit tests verifying localization loading and duplicate detection
- Test compendium initialization, retrieval, and class utilities
- Ensure character and class behaviors through targeted tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3adad083883328e6dcb577e38c8b5